### PR TITLE
fix: update Quick Start section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ module.exports = {
 3. **Create** `config/csv-exporter.ts` in your Strapi project:
 
 ```javascript
-import type { CSVExporterPlugin } from "strapi-plugin-csv-exporter/dist/server/src";
+import type { CSVExporterPlugin } from "strapi-plugin-csv-exporter/strapi-server";
 
 module.exports = (): CSVExporterPlugin => ({
   // Content type specific configurations
@@ -80,6 +80,7 @@ module.exports = (): CSVExporterPlugin => ({
       }
 
     },
+  },
 
   // Optional: Global date formatting for all fields that are a valid ISO Date
   dateFormat: 'dd/MM/yyyy HH:mm', // default
@@ -87,7 +88,7 @@ module.exports = (): CSVExporterPlugin => ({
   timeZone: '+00:00', // default
   // Optional: Fields to globally ignore in exports
   ignore: [], // default
-};
+});
 ```
 
 4. **Build and restart** your Strapi application


### PR DESCRIPTION
Hi, I'm using your package and looks great. However, I tried following the instructions in the Quick Start guide, but it didn't work until I realize there were a couple of typos.

So I'm just opening this PR just in case you allow me to contribute to this by fixing the error in the documentation. Thanks!

🐛 Problem

The Quick Start section in the README contains syntax errors that prevent the configuration from working when copy-pasted:

1. **Incorrect import path**: The import statement referenced `strapi-plugin-csv-exporter/dist/server/src` instead of the correct `strapi-plugin-csv-exporter/strapi-server`.
2. **Missing closing brace**: The config object was not properly closed before the global options.
3. **Wrong closing syntax**: Used `};` instead of `});` to match the arrow function syntax.

These errors cause TypeScript compilation failures and runtime errors when users follow the setup instructions.

✅ Solution
- Updated import path to `strapi-plugin-csv-exporter/strapi-server` (the correct public export).
- Added missing `}` to properly close the config object.
- Changed closing from `};` to `});` to match the arrow function declaration.

🧪 Testing
Copy-pasted the corrected configuration into a fresh Strapi project and verified:

- TypeScript compilation succeeds without errors
- Plugin loads and functions correctly
- Configuration is properly typed with IntelliSense support

📝 Changes
- Modified the code example in the Quick Start section (step 3)
- No functional changes to the plugin code itself