### PR TITLE
fix: correct handling of default locale values 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ module.exports = {
 3. **Create** `config/csv-exporter.ts` in your Strapi project:
 
 ```javascript
+// for strapi tsconfig
+//  "module": "CommonJS",
+//  "moduleResolution": "Node",
+// use
+//
+// import type { CSVExporterPlugin } from "strapi-plugin-csv-exporter/dist/server/src";
+//
+// for
+//  "module": "Node16",
+//  "moduleResolution": "Node16",
 import type { CSVExporterPlugin } from "strapi-plugin-csv-exporter/strapi-server";
 
 module.exports = (): CSVExporterPlugin => ({

--- a/admin/src/pages/HomePage.tsx
+++ b/admin/src/pages/HomePage.tsx
@@ -35,7 +35,7 @@ const HomePage = () => {
   const [sortedColumns, setSortedColumns] = useState<string[]>([]);
   const [tableData, setTableData] = useState<Array<Record<string, string>>>([]);
   const [selectedValue, setSelectedValue] = useState<string | null>(null);
-  const [selectedLocale, setSelectedLocale] = useState<string>('de');
+  const [selectedLocale, setSelectedLocale] = useState<string>('');
   const [isLoading, setIsLoading] = useState(true);
   const [isSuccessMessage, setIsSuccessMessage] = useState(false);
   const [isError, setIsError] = useState(false);
@@ -51,6 +51,13 @@ const HomePage = () => {
       try {
         const { data } = await get('/csv-exporter/dropdownvalues');
         setDropDownData(data);
+
+        if (data.defaultLocale) {
+          setSelectedLocale(data.defaultLocale);
+        } else if (data.locales?.length > 0) {
+          setSelectedLocale(data.locales[0].value);
+        }
+
         setIsLoading(false);
       } catch (error) {
         console.error('Error fetching dropdown value:', error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strapi-plugin-csv-exporter",
-  "version": "5.5.1-experimental.0",
+  "version": "5.5.1-experimental.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strapi-plugin-csv-exporter",
-      "version": "5.5.1-experimental.0",
+      "version": "5.5.1-experimental.1",
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "1.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strapi-plugin-csv-exporter",
-  "version": "5.5.0",
+  "version": "5.5.1-experimental.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strapi-plugin-csv-exporter",
-      "version": "5.5.0",
+      "version": "5.5.1-experimental.0",
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.5.0",
+  "version": "5.5.1-experimental.0",
   "keywords": [
     "strapi",
     "plugin",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.5.1-experimental.0",
+  "version": "5.5.0",
   "keywords": [
     "strapi",
     "plugin",

--- a/server/src/services/service.ts
+++ b/server/src/services/service.ts
@@ -80,11 +80,15 @@ const service = ({ strapi }: { strapi: Core.Strapi }) => ({
       );
 
       const query = await restructureObject(config[uid], validatedFilters, limit, offset);
+
+      const localesService = strapi.plugin('i18n').service('locales');
+      const locales = await localesService.find();
+
       const response = await strapi.documents(uid).findMany({
         ...query,
         filters: {
           ...query.filters,
-          locale,
+          ...(Array.isArray(locales) && locales.length > 1 ? { locale } : {}),
         },
       });
 
@@ -102,7 +106,7 @@ const service = ({ strapi }: { strapi: Core.Strapi }) => ({
 
       const count = await strapi.documents(uid).count({
         filters: {
-          locale,
+          ...(Array.isArray(locales) && locales.length > 1 ? { locale } : {}),
         },
       });
 
@@ -138,12 +142,15 @@ const service = ({ strapi }: { strapi: Core.Strapi }) => ({
         strapi.contentTypes[uid].attributes
       );
 
+      const localesService = strapi.plugin('i18n').service('locales');
+      const locales = await localesService.find();
+
       const query = await restructureObject(config[uid], validatedFilters);
       const response = await strapi.documents(uid).findMany({
         ...query,
         filters: {
           ...query.filters,
-          locale,
+          ...(Array.isArray(locales) && locales.length > 1 ? { locale } : {}),
         },
       });
       const csvData = await restructureData(response, config[uid], uid, {

--- a/server/src/utils/data-format.ts
+++ b/server/src/utils/data-format.ts
@@ -59,7 +59,6 @@ export const restructureObject = async (
   offset?: number
 ) => {
   const filters = {
-    locale: 'en',
     ...(filter || {}),
   };
 

--- a/server/src/utils/index.ts
+++ b/server/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './data-format';
 export * from './validate-filter';
+export * from './locale';

--- a/server/src/utils/locale.ts
+++ b/server/src/utils/locale.ts
@@ -1,0 +1,14 @@
+import type { Core } from '@strapi/strapi';
+
+export const getDefaultLocale = async (strapi: Core.Strapi): Promise<string> => {
+  try {
+    const defaultLocale = await strapi.plugin('i18n').service('locales').getDefaultLocale();
+    if (defaultLocale) {
+      return defaultLocale;
+    }
+  } catch (error) {
+    strapi.log.warn('Could not determine default locale from i18n settings:', error);
+  }
+
+  return 'en';
+};


### PR DESCRIPTION
Fixes #3 (wrong usage of locale filter if only one locale is activated in strapi)
Fixes state gets initialised with 'de' even if not present
Fixes backend relying on 'en' (tries to get default local for service before final fallback now)